### PR TITLE
Add development venv requirements.txt

### DIFF
--- a/venvs/development/requirements.txt
+++ b/venvs/development/requirements.txt
@@ -1,0 +1,3 @@
+black
+pre-commit
+pytest>4.1


### PR DESCRIPTION
Add the start of a `venv` that allows for cleanly writing and testing Python projects.